### PR TITLE
Make blog routes refresh from Notion

### DIFF
--- a/src/app/blog/category/[category]/page.tsx
+++ b/src/app/blog/category/[category]/page.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { categorizePostCategory, isTopCategoryKey } from '@/lib/blogCategories';
 
+export const dynamic = 'force-dynamic';
+
 interface CategoryPageProps {
   params: Promise<{ category: string }>;
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link';
 import { FaCode, FaFutbol, FaHeart } from 'react-icons/fa';
 import { categorizePostCategory } from '@/lib/blogCategories';
 
+export const dynamic = 'force-dynamic';
+
 export default async function BlogPage() {
   let posts: Awaited<ReturnType<typeof getBlogPosts>> = [];
   let error: string | null = null;


### PR DESCRIPTION
## Summary
- force the blog index route to render dynamically
- force the blog category route to render dynamically
- prevent stale Notion-backed blog counts on the portfolio site

## Testing
- npm run build
- confirmed /blog and /blog/category/[category] build as dynamic routes
