### PR TITLE
hotfix: simplify about and experience scrolling

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,12 +1,6 @@
-// the about page component that displays the about me section
-
-"use client";
-
-import { useState, useEffect } from "react";
 import Image from "next/image";
 
-// reusable full-screen slide component (declared as a type which is similar to an interface)
-type SlideProps = {
+type SectionProps = {
   imgSrc: string;
   imgAlt: string;
   title: string;
@@ -14,22 +8,18 @@ type SlideProps = {
   reverse?: boolean;
 };
 
-function Slide({ // destructuring the props, each prop becomes a local variable
+function AboutSection({
   imgSrc,
   imgAlt,
   title,
   description,
   reverse = false,
-}: SlideProps) {
+}: SectionProps) {
   return (
-    <section
-      className="flex min-h-screen flex-col items-center justify-center px-6 py-10 sm:flex-row lg:justify-center"
-    >
+    <section className="flex min-h-[calc(100dvh-3.5rem)] flex-col items-center justify-center px-6 py-12 sm:flex-row lg:justify-center">
       {reverse ? (
         <>
-          <div
-            className="max-w-xl space-y-4 text-center sm:text-left sm:mr-12"
-          >
+          <div className="max-w-xl space-y-4 text-center sm:mr-12 sm:text-left">
             <h2 className="text-4xl font-bold text-foreground">{title}</h2>
             <p className="text-lg text-muted-foreground">{description}</p>
           </div>
@@ -48,11 +38,9 @@ function Slide({ // destructuring the props, each prop becomes a local variable
             alt={imgAlt}
             width={320}
             height={320}
-            className="mb-8 h-72 w-72 rounded-2xl object-cover shadow-xl sm:mb-0 sm:h-80 sm:w-80 sm:mr-12"
+            className="mb-8 h-72 w-72 rounded-2xl object-cover shadow-xl sm:mb-0 sm:mr-12 sm:h-80 sm:w-80"
           />
-          <div
-            className="max-w-xl space-y-4 text-center sm:text-left"
-          >
+          <div className="max-w-xl space-y-4 text-center sm:text-left">
             <h2 className="text-4xl font-bold text-foreground">{title}</h2>
             <p className="text-lg text-muted-foreground">{description}</p>
           </div>
@@ -62,8 +50,7 @@ function Slide({ // destructuring the props, each prop becomes a local variable
   );
 }
 
-// define slides data
-const slides = [
+const sections = [
   {
     imgSrc: "/kevin-big.jpeg",
     imgAlt: "Portrait of Kevin",
@@ -83,112 +70,11 @@ const slides = [
 ];
 
 export default function About() {
-  const [currentSlide, setCurrentSlide] = useState(0); // state to track the current slide  
-  const [touchStart, setTouchStart] = useState(0); // state to track the touch start position
-  const [touchEnd, setTouchEnd] = useState(0); // state to track the touch end position
-  const [isScrolling, setIsScrolling] = useState(false); // state to track if the user is scrolling
-
-  // Touch handlers for swipe detection
-  const onTouchStart = (e: React.TouchEvent) => {
-    setTouchStart(e.targetTouches[0].clientY);
-  };
-
-  const onTouchMove = (e: React.TouchEvent) => {
-    setTouchEnd(e.targetTouches[0].clientY);
-  };
-
-  const onTouchEnd = () => {
-    if (!touchStart || !touchEnd || isScrolling) return; // if the touch start or touch end is not defined, or the isScrolling state is true, then return
-
-    const distance = touchStart - touchEnd;
-    const isSwipeUp = distance > 50; // Swipe up threshold - if the distance is greater than 50, then it is a swipe up
-    const isSwipeDown = distance < -50; // Swipe down threshold - if the distance is less than -50, then it is a swipe down
-
-    if (isSwipeDown && currentSlide > 0) {
-      // Swipe down - go to previous slide
-      setCurrentSlide(currentSlide - 1);
-      setIsScrolling(true);
-      setTimeout(() => setIsScrolling(false), 500); // 500ms cooldown - set the isScrolling state to false after 500ms
-    } else if (isSwipeUp && currentSlide < slides.length - 1) {
-      // Swipe up - go to next slide
-      setCurrentSlide(currentSlide + 1);
-      setIsScrolling(true);
-      setTimeout(() => setIsScrolling(false), 500); // 500ms cooldown - set the isScrolling state to false after 500ms
-    }
-
-    // Reset touch values
-    setTouchStart(0);
-    setTouchEnd(0);
-  };
-
-  // Mouse wheel navigation for desktop with debouncing
-  const onWheel = (e: React.WheelEvent) => {
-    if (isScrolling) return; // Prevent rapid scrolling
-
-    if (e.deltaY > 0 && currentSlide < slides.length - 1) {
-      // Scroll down - go to next slide
-      setCurrentSlide(currentSlide + 1);
-      setIsScrolling(true);
-      setTimeout(() => setIsScrolling(false), 500); // 500ms cooldown
-    } else if (e.deltaY < 0 && currentSlide > 0) {
-      // Scroll up - go to previous slide
-      setCurrentSlide(currentSlide - 1);
-      setIsScrolling(true);
-      setTimeout(() => setIsScrolling(false), 500); // 500ms cooldown
-    }
-  };
-
-  // Keyboard navigation
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (isScrolling) return; // Prevent rapid key presses
-
-      if (e.key === 'ArrowDown' && currentSlide < slides.length - 1) { // if the arrow down key is pressed and the current slide is less than the length of the slides, then go to the next slide
-        setCurrentSlide(currentSlide + 1);
-        setIsScrolling(true);
-        setTimeout(() => setIsScrolling(false), 500); // 500ms cooldown - set the isScrolling state to false after 500ms
-      } else if (e.key === 'ArrowUp' && currentSlide > 0) { // if the arrow up key is pressed and the current slide is greater than 0, then go to the previous slide
-        setCurrentSlide(currentSlide - 1);
-        setIsScrolling(true);
-        setTimeout(() => setIsScrolling(false), 500); // 500ms cooldown - set the isScrolling state to false after 500ms
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown); // add the event listener for the keydown event
-    return () => window.removeEventListener('keydown', handleKeyDown); // remove the event listener for the keydown event when the component unmounts
-  }, [currentSlide, isScrolling]);
-
   return (
-    <div
-      className="h-[calc(100dvh-3.5rem)] w-full bg-background overflow-hidden"
-      onTouchStart={onTouchStart}
-      onTouchMove={onTouchMove}
-      onTouchEnd={onTouchEnd}
-      onWheel={onWheel}
-    >
-      {/* Slide indicator */}
-      <div className="fixed top-1/2 right-6 z-50 flex flex-col space-y-2">
-        {slides.map((_, index) => (
-          <div
-            key={index}
-            className={`w-3 h-3 rounded-full transition-all duration-300 ${index === currentSlide
-              ? 'bg-foreground scale-125'
-              : 'bg-muted-foreground/30'
-              }`}
-          />
-        ))}
-      </div>
-
-      {/* Current slide */}
-      <div className="h-full flex items-center justify-center">
-        <Slide
-          imgSrc={slides[currentSlide].imgSrc}
-          imgAlt={slides[currentSlide].imgAlt}
-          title={slides[currentSlide].title}
-          description={slides[currentSlide].description}
-          reverse={slides[currentSlide].reverse}
-        />
-      </div>
+    <div className="w-full bg-background">
+      {sections.map((section) => (
+        <AboutSection key={section.title} {...section} />
+      ))}
     </div>
   );
 }

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -1,101 +1,17 @@
-"use client"
-
-import { useState, useEffect } from "react"
-import experiences from "@/data/experiences"
-import WorkExperience from "@/components/WorkExperience"
+import experiences from "@/data/experiences";
+import WorkExperience from "@/components/WorkExperience";
 
 export default function ExperiencePage() {
-  const [currentExperience, setCurrentExperience] = useState(0)
-  const [touchStart, setTouchStart] = useState(0)
-  const [touchEnd, setTouchEnd] = useState(0)
-  const [isScrolling, setIsScrolling] = useState(false)
-
-  const onTouchStart = (e: React.TouchEvent) => {
-    setTouchStart(e.targetTouches[0].clientX)
-  }
-
-  const onTouchMove = (e: React.TouchEvent) => {
-    setTouchEnd(e.targetTouches[0].clientX)
-  }
-
-  const onTouchEnd = () => {
-    if (!touchStart || !touchEnd || isScrolling) return
-
-    const distance = touchStart - touchEnd
-    const isSwipeLeft = distance > 50
-    const isSwipeRight = distance < -50
-
-    if (isSwipeLeft && currentExperience < experiences.length - 1) {
-      setCurrentExperience(currentExperience + 1)
-      setIsScrolling(true)
-      setTimeout(() => setIsScrolling(false), 350)
-    } else if (isSwipeRight && currentExperience > 0) {
-      setCurrentExperience(currentExperience - 1)
-      setIsScrolling(true)
-      setTimeout(() => setIsScrolling(false), 350)
-    }
-
-    setTouchStart(0)
-    setTouchEnd(0)
-  }
-
-  const onWheel = (e: React.WheelEvent) => {
-    if (isScrolling) return
-
-    const dominantDelta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY
-
-    if (dominantDelta > 0 && currentExperience < experiences.length - 1) {
-      setCurrentExperience(currentExperience + 1)
-      setIsScrolling(true)
-      setTimeout(() => setIsScrolling(false), 350)
-    } else if (dominantDelta < 0 && currentExperience > 0) {
-      setCurrentExperience(currentExperience - 1)
-      setIsScrolling(true)
-      setTimeout(() => setIsScrolling(false), 350)
-    }
-  }
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (isScrolling) return
-
-      if (e.key === "ArrowRight" && currentExperience < experiences.length - 1) {
-        setCurrentExperience(currentExperience + 1)
-        setIsScrolling(true)
-        setTimeout(() => setIsScrolling(false), 350)
-      } else if (e.key === "ArrowLeft" && currentExperience > 0) {
-        setCurrentExperience(currentExperience - 1)
-        setIsScrolling(true)
-        setTimeout(() => setIsScrolling(false), 350)
-      }
-    }
-
-    window.addEventListener("keydown", handleKeyDown)
-    return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [currentExperience, isScrolling])
-
   return (
-    <div
-      className="h-[calc(100dvh-3.5rem)] w-full bg-background overflow-hidden"
-      onTouchStart={onTouchStart}
-      onTouchMove={onTouchMove}
-      onTouchEnd={onTouchEnd}
-      onWheel={onWheel}
-    >
-      <div className="fixed right-4 top-1/2 z-50 hidden -translate-y-1/2 gap-2 md:flex md:flex-col">
-        {experiences.map((_, index) => (
-          <div
-            key={index}
-            className={`h-3 w-3 rounded-full transition-all duration-300 ${index === currentExperience ? "bg-foreground scale-125" : "bg-muted-foreground/30"}`}
+    <div className="w-full bg-background px-3 py-6 sm:px-6 sm:py-10">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 sm:gap-8">
+        {experiences.map((experience) => (
+          <WorkExperience
+            key={`${experience.company}-${experience.role}`}
+            {...experience}
           />
         ))}
       </div>
-
-      <div className="flex h-full items-center justify-center px-3 py-3 sm:px-6 sm:py-6">
-        <div className="w-full max-w-5xl">
-          <WorkExperience {...experiences[currentExperience]} />
-        </div>
-      </div>
     </div>
-  )
+  );
 }

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -1,7 +1,5 @@
-"use client";
-import { useMemo } from "react";
 import { TechTool } from "@/data/techIcons";
-import React from "react"; // Added missing import for React
+import React from "react";
 
 type WorkExperienceProps = {
   role: string;
@@ -22,55 +20,54 @@ export default function WorkExperience({
   description,
   tools,
 }: WorkExperienceProps) {
-  const safeTools = useMemo(() => tools ?? [], [tools]);
+  const safeTools = tools ?? [];
 
   return (
-    <section className="flex items-center justify-center">
-      <div className="bg-card border border-border rounded-xl p-5 sm:p-8 shadow-lg hover:shadow-xl max-w-4xl w-full max-h-[calc(100dvh-7.5rem)] overflow-y-auto">
-        <div className="grid gap-6 md:grid-cols-2 md:gap-8 items-start">
-          {/* Left side - Company logo and info */}
-          <div className="text-center space-y-5 sm:space-y-8">
-            <h2 className="text-2xl sm:text-3xl font-bold text-foreground">
+    <section className="flex w-full justify-center">
+      <div className="w-full max-w-4xl rounded-xl border border-border bg-card p-5 shadow-lg transition-shadow hover:shadow-xl sm:p-8">
+        <div className="grid items-start gap-6 md:grid-cols-2 md:gap-8">
+          <div className="space-y-5 text-center sm:space-y-8">
+            <h2 className="text-2xl font-bold text-foreground sm:text-3xl">
               {role}
             </h2>
 
-            <h3 className="text-lg sm:text-xl font-semibold text-foreground">
+            <h3 className="text-lg font-semibold text-foreground sm:text-xl">
               {company}
             </h3>
 
-            <p
-              className="text-sm text-muted-foreground"
-            >
+            <p className="text-sm text-muted-foreground">
               {location} • {startDate} – {endDate}
             </p>
           </div>
 
-          {/* Right side - Description and tech stack */}
           <div className="space-y-5 sm:space-y-6">
-            {/* Description */}
             <div>
-              <h4 className="text-lg font-semibold text-foreground mb-3">Key Responsibilities</h4>
-              <ul className="list-disc list-inside text-muted-foreground text-sm space-y-2">
+              <h4 className="mb-3 text-lg font-semibold text-foreground">
+                Key Responsibilities
+              </h4>
+              <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground">
                 {description.map((item, i) => (
-                  <li
-                    key={i}
-                  >
-                    {item}
-                  </li>
+                  <li key={i}>{item}</li>
                 ))}
               </ul>
             </div>
 
-            {/* Tech Stack Section */}
             {safeTools.length > 0 && (
               <div className="border-t border-border pt-6">
                 <div className="grid grid-cols-3 gap-3 sm:gap-4">
                   {safeTools.slice(0, 9).map((tool) => (
-                    <div key={tool.name} className="flex flex-col items-center text-center">
-                      <div className="text-2xl sm:text-3xl text-foreground">
-                        {React.createElement(tool.icon, { className: "w-8 h-8 sm:w-10 sm:h-10 fill-current" })}
+                    <div
+                      key={tool.name}
+                      className="flex flex-col items-center text-center"
+                    >
+                      <div className="text-2xl text-foreground sm:text-3xl">
+                        {React.createElement(tool.icon, {
+                          className: "h-8 w-8 fill-current sm:h-10 sm:w-10",
+                        })}
                       </div>
-                      <div className="mt-1 text-xs text-muted-foreground font-medium">{tool.name}</div>
+                      <div className="mt-1 text-xs font-medium text-muted-foreground">
+                        {tool.name}
+                      </div>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- remove the snap-style slide/carousel behavior from the about page
- render all work experiences in a normal vertical flow instead of one-at-a-time navigation
- remove the nested scroll area inside experience cards so the page scrolls naturally

## Testing
- npm run lint
- npm run build -- --webpack